### PR TITLE
Mount ssh key from secret if available.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM aiidalab/aiidalab-docker-stack:21.07.0rc1
 
 USER root
 
-
 # Install simulation engines.
 RUN conda install --yes -c conda-forge \
   qe==6.7.0 \
@@ -16,6 +15,9 @@ RUN pip install -r requirements.txt
 RUN reentry scan
 
 # Prepare user's folders for AiiDAlab launch.
+
+# Mount ssh key from secret (if available).
+COPY my_init.d/mount-ssh-from-secret.sh /etc/my_init.d/09_mount-ssh-from-secret.sh
 COPY opt/setup_optional_things.sh /opt/
 COPY my_init.d/setup_optional_things.sh /etc/my_init.d/90_setup_optional_things.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,8 @@ services:
       - JUPYTER_TOKEN
     volumes:
       - ~/aiidalab:/home/aiida
+    secrets:
+      - ssh_key
+secrets:
+  ssh_key:
+    file: ~/.ssh/id_rsa

--- a/my_init.d/mount-ssh-from-secret.sh
+++ b/my_init.d/mount-ssh-from-secret.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -eux
+
+if [ ! -d /home/${SYSTEM_USER}/.ssh/ ] && [ -f /run/secrets/ssh_key ]; then
+  mkdir --mode=0700 /home/${SYSTEM_USER}/.ssh/
+  touch /home/${SYSTEM_USER}/.ssh/known_hosts
+  # Linking ssh key from secret.
+  ln -s /run/secrets/ssh_key /home/${SYSTEM_USER}/.ssh/id_rsa
+
+  # Try to fix permissions (should fail when user was not yet created).
+  chown -R ${SYSTEM_USER}:${SYSTEM_USER} /home/${SYSTEM_USER}/.ssh || echo "initial startup"
+fi


### PR DESCRIPTION
Enable the mounting of a user ssh key file from a docker secret.