### PR TITLE
Marketplace deploy: store access_token as env variable during spawner process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
   deploy-marketplace:
 
     needs: [build-docker-image]
-    if: github.ref == 'refs/heads/marketplace'
+    if: github.ref == 'refs/heads/main'
 
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - develop
       - main
+      - marketplace
 
 jobs:
 
@@ -191,7 +192,7 @@ jobs:
   deploy-marketplace:
 
     needs: [build-docker-image]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/marketplace'
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -210,9 +211,10 @@ jobs:
       image_name: ${{ github.repository }}
       image_tag: ${{ needs.build-docker-image.outputs.tag }}
       jh_host: materials-marketplace.aiidalab.net
+      jh_crypt_key: ${{ secrets.JUPYTERHUB_CRYPT_KEY }}
 
       marketplace_host: staging.the-marketplace.eu
-      oauth_client_id: "04366497-2d3f-4cc4-8c1a-b6a4a7fa68b7" 
+      oauth_client_id: "2c7c68ab-84b3-45e6-b3d8-fe87f64937e3" 
       oauth_client_secret: ${{ secrets.OAUTH_CLIENT_SECRET }}
       secret_token: ${{ secrets.SECRET_TOKEN }}
       oauth_scope: "['email', 'profile', 'openid', 'offline']"

--- a/.github/workflows/config-template.yaml.j2
+++ b/.github/workflows/config-template.yaml.j2
@@ -59,6 +59,10 @@ hub:
     DummyAuthenticator:
       password: "{{ auth_password }}"
   {%- endif %}
+
+{%- else %} # marketplace
+  extraEnv:
+    JUPYTERHUB_CRYPT_KEY: {{ jh_crypt_key }}
 {%- endif %}
 
   db:
@@ -78,6 +82,7 @@ hub:
       c.JupyterHub.authenticator_class = MarketplaceOAuthenticator
       c.JupyterHub.admin_access = True
 
+      c.MarketplaceOAuthenticator.enable_auth_state = True
       c.MarketplaceOAuthenticator.client_id = "{{ oauth_client_id }}"
       c.MarketplaceOAuthenticator.client_secret = "{{ oauth_client_secret }}"
       c.MarketplaceOAuthenticator.oauth_callback_url = 'https://{{ jh_host }}/hub/oauth_callback'

--- a/.github/workflows/config-template.yaml.j2
+++ b/.github/workflows/config-template.yaml.j2
@@ -81,6 +81,12 @@ hub:
 
       c.JupyterHub.authenticator_class = MarketplaceOAuthenticator
       c.JupyterHub.admin_access = True
+      c.JupyterHub.extra_handlers = [
+        (
+          r'/termsAndConditions',
+          TermsConditionsHandler,
+        ),
+      ]
 
       c.MarketplaceOAuthenticator.enable_auth_state = True
       c.MarketplaceOAuthenticator.client_id = "{{ oauth_client_id }}"

--- a/.github/workflows/config-template.yaml.j2
+++ b/.github/workflows/config-template.yaml.j2
@@ -37,7 +37,10 @@ singleuser:
   startTimeout: 600
 
 hub:
-{%- if RELEASE != 'aiidalab-marketplace' %}
+{%- if RELEASE == 'aiidalab-marketplace' %}
+  extraEnv:
+    JUPYTERHUB_CRYPT_KEY: {{ jh_crypt_key }}
+{%- else %}
   config:
     JupyterHub:
       authenticator_class: {{ authenticator_class }}
@@ -59,10 +62,6 @@ hub:
     DummyAuthenticator:
       password: "{{ auth_password }}"
   {%- endif %}
-
-{%- else %} # marketplace
-  extraEnv:
-    JUPYTERHUB_CRYPT_KEY: {{ jh_crypt_key }}
 {%- endif %}
 
   db:

--- a/marketplace/oauthenticator.py
+++ b/marketplace/oauthenticator.py
@@ -3,6 +3,25 @@ from oauthenticator.generic import GenericOAuthenticator
 
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 
+from jupyterhub.handlers.base import BaseHandler
+
+# add route for terms & conditions
+class HeartbeatHandler(BaseHandler):
+
+    def get(self): # pylint: disable=arguments-differ
+        """heartbeat"""
+        self.write("exist is pain.")
+
+        return
+    
+class LoginHandler(BaseHandler):
+
+    def get(self): # pylint: disable=arguments-differ
+        """heartbeat"""
+        self.write("login by me.")
+
+        return
+
 class MarketplaceOAuthenticator(GenericOAuthenticator):
     """A GenericOAuthenticator with assigned LoginHandler containing Marketplace specific urls"""
 
@@ -35,7 +54,6 @@ class MarketplaceOAuthenticator(GenericOAuthenticator):
 
         # Get full user details
         access_token = resp_json['auth_state']['access_token']
-        refresh_token = resp_json['auth_state']['refresh_token']
         user_json = await self._fetch_user_details(access_token)
 
         # Update real username and store additional details in in auth_state
@@ -43,3 +61,12 @@ class MarketplaceOAuthenticator(GenericOAuthenticator):
         resp_json['auth_state']['oauth_user'].update(user_json)
 
         return resp_json
+
+    async def pre_spawn_start(self, user, spawner):
+        """Pass upstream_token to spawner via environment variable"""
+        auth_state = await user.get_auth_state()
+        if not auth_state:
+            # auth_state not enabled
+            return
+        spawner.environment['MP_ACCESS_TOKEN'] = auth_state['access_token']
+        spawner.environment['MP_REFRESH_TOKEN'] = auth_state['refresh_token']

--- a/marketplace/oauthenticator.py
+++ b/marketplace/oauthenticator.py
@@ -6,22 +6,14 @@ from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 from jupyterhub.handlers.base import BaseHandler
 
 # add route for terms & conditions
-class HeartbeatHandler(BaseHandler):
+class TermsConditionsHandler(BaseHandler):
 
     def get(self): # pylint: disable=arguments-differ
-        """heartbeat"""
-        self.write("exist is pain.")
+        """Terms and conditions"""
+        self.write("This is the terms and conditions of this service.")
 
         return
     
-class LoginHandler(BaseHandler):
-
-    def get(self): # pylint: disable=arguments-differ
-        """heartbeat"""
-        self.write("login by me.")
-
-        return
-
 class MarketplaceOAuthenticator(GenericOAuthenticator):
     """A GenericOAuthenticator with assigned LoginHandler containing Marketplace specific urls"""
 

--- a/marketplace/oauthenticator.py
+++ b/marketplace/oauthenticator.py
@@ -10,9 +10,9 @@ class TermsConditionsHandler(BaseHandler):
 
     def get(self): # pylint: disable=arguments-differ
         """Terms and conditions"""
+        # Note: This placeholder serves a demonstration for adding
+        # additional routes and associated handlers.
         self.write("This is the terms and conditions of this service.")
-
-        return
     
 class MarketplaceOAuthenticator(GenericOAuthenticator):
     """A GenericOAuthenticator with assigned LoginHandler containing Marketplace specific urls"""

--- a/marketplace/openapi-qeapp.yml
+++ b/marketplace/openapi-qeapp.yml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+ 
+info:
+  title: API description of a Marketplace Application
+  description: 'OpenAPI Specification of the Application registration API'
+  version: '0.1.0'
+  x-application-name: AiiDA-lab-QEapp
+  x-application-id: 2c7c68ab-84b3-45e6-b3d8-fe87f64937e3
+  x-mp-api: http://marketplace.org/ontology/v1_0_0/api_spec
+  x-external-hostname: https://materials-marketplace.aiidalab.net/
+  x-image: https://raw.githubusercontent.com/aiidalab/aiidalab-widgets-base/master/miscellaneous/logos/aiidalab.png
+  x-products:
+    - name: QE App
+      productId: 87f0189b-00b7-4ae3-a017-8d85e766d3d5
+servers:
+  - url: https://materials-marketplace.aiidalab.net/
+
+paths:
+# Administrative paths
+  /hub/user-redirect/apps/apps/quantum-espresso/qe.ipynb:
+    get:
+      description: frontend path
+      operationId: frontend
+      responses:
+        '200':
+          description: Success
+        '404':
+          description: Page not found
+
+  /hub/health:
+    get:
+      description: To check if an application is alive
+      operationId: heartbeat
+      responses:
+        '200':
+          description: Success
+        '404':
+          description: Not found
+ 
+components:
+  securitySchemes:
+    AuthHeader:        
+      type: apiKey
+      in: header       
+      name: Authorization  

--- a/marketplace/openapi-ssspapp.yml
+++ b/marketplace/openapi-ssspapp.yml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+ 
+info:
+  title: API description of a Marketplace Application
+  description: 'OpenAPI Specification of the Application registration API'
+  version: '0.1.0'
+  x-application-name: AiiDA-lab-SSSPapp
+  x-application-id: 2c7c68ab-84b3-45e6-b3d8-fe87f64937e3
+  x-mp-api: http://marketplace.org/ontology/v1_0_0/api_spec
+  x-external-hostname: https://materials-marketplace.aiidalab.net/
+  x-image: https://raw.githubusercontent.com/aiidalab/aiidalab-widgets-base/master/miscellaneous/logos/aiidalab.png
+  x-products:
+    - name: SSSP App
+      productId: 87f0189b-00b7-4ae3-a017-8d85e766d3d5
+servers:
+  - url: https://materials-marketplace.aiidalab.net/
+
+paths:
+# Administrative paths
+  /hub/user-redirect/apps/apps/aiidalab-sssp/verification.ipynb:
+    get:
+      description: frontend path
+      operationId: frontend
+      responses:
+        '200':
+          description: Success
+        '404':
+          description: Page not found
+
+  /hub/health:
+    get:
+      description: To check if an application is alive
+      operationId: heartbeat
+      responses:
+        '200':
+          description: Success
+        '404':
+          description: Not found
+ 
+components:
+  securitySchemes:
+    AuthHeader:        
+      type: apiKey
+      in: header       
+      name: Authorization  

--- a/marketplace/register.md
+++ b/marketplace/register.md
@@ -1,0 +1,5 @@
+curl -X POST \
+   -H "Authorization:Bearer pqOk-ddeyeDNnrSSVwcbuNRMnITwyQcLmE_kbrvV30Y.vUGfxcwdaae3pwORqDED6NNAb2k24AM3tPNm19qS8zw" \
+   -H "Content-Type:multipart/form-data" \
+   -F "openapi=@openapi.yml" \
+   'https://staging.the-marketplace.eu/application/register'


### PR DESCRIPTION
I now very doubt it is necessary to store the token inside aiidalab app implementation. The initial purpose of storing the token in jupyterhub is to interact with other marketplace applications by the GUI of QeApp. Do we still want to do interaction in this way or we just want to call and run simulation on QeApp application by its Marketplace API?